### PR TITLE
Version 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and [human-readable changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## master
 
+## 0.0.4
+
+### Fixed
+
+- Remove the path to the license file because license must be exclusive.
+
 ## 0.0.3
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,14 +1,12 @@
 ---
 namespace: 'sbaerlocher'
 name: 'virtualization'
-version: 0.0.3
+version: 0.0.4
 readme: README.md
 authors:
   - 'Simon Baerlocher (https://sbaerlocher.ch)'
 description: 'Ansible Collection for virtualization.'
-license:
-  - MIT
-license_file: 'LICENSE'
+license: MIT
 tags:
   - virtualization
 dependencies: {}


### PR DESCRIPTION
### Fixed

- Remove the path to the license file because license must be exclusive.